### PR TITLE
Interface method name change

### DIFF
--- a/getting-started/overview.md
+++ b/getting-started/overview.md
@@ -17,7 +17,7 @@ The `preProcess` interception point happens before any event executes in a ColdB
 How does the interceptor know a user doesn't or does have access? Well, here is where you register a Validator CFC \(`validator` setting\) with the interceptor that implements two validation functions: `ruleValidator()` and `annotationValidator()` that will allow the module to know if the user is logged in and has the right authorizations to continue with the execution.
 
 {% hint style="info" %}
-You can find an interface for these methods in `cbsecurity.interfaces.IUserValidator`
+You can find an interface for these methods in `cbsecurity.interfaces.ISecurityValidator`
 {% endhint %}
 
 The validator's job is to tell back to the firewall if they are allowed access and if they don't, what type of validation they broke: **authentication** or **authorization**.


### PR DESCRIPTION
Looks like cbsecurity.interfaces.IUserValidator should be cbsecurity.interfaces.ISecurityValidator