### PR TITLE
permissions are a list so listfindnocase

### DIFF
--- a/jwt/jwt-services.md
+++ b/jwt/jwt-services.md
@@ -285,7 +285,7 @@ component accessors="true" {
 
 		return arguments.permission
 			.filter( function(item){
-				return ( variables.permissions.findNoCase( item ) );
+				return ( variables.permissions.ListFindNoCase( item ) );
 			} )
 			.len();
 	}


### PR DESCRIPTION
In function hasPermission the filter is doing a findnocase against a list of permissions for each permission in the arguments.  If the list of permissions were, for instance, "view,edit,delete" then a permission called "iew" would pass.  Not a very good example but I noticed using some tests of similar permission values that things weren't quite right.  I believe should be ListFindNoCase instead.