### PR TITLE
Fix typo in cbsecurity configuration docs

### DIFF
--- a/getting-started/first-chapter/README.md
+++ b/getting-started/first-chapter/README.md
@@ -12,7 +12,7 @@ moduleSettings = {
 	cbSecurity : {
 		// The global invalid authentication event or URI or URL to go if an invalid authentication occurs
 		"invalidAuthenticationEvent"	: "",
-		// Default Auhtentication Action: override or redirect when a user has not logged in
+		// Default Authentication Action: override or redirect when a user has not logged in
 		"defaultAuthenticationAction"	: "redirect",
 		// The global invalid authorization event or URI or URL to go if an invalid authorization occurs
 		"invalidAuthorizationEvent"		: "",


### PR DESCRIPTION
It's `Authentication`, not `Auhtentication`. :)