### PR TITLE
docs(moduleRules): Added module rule source docs

### DIFF
--- a/getting-started/first-chapter/rule-sources/module-rules.md
+++ b/getting-started/first-chapter/rule-sources/module-rules.md
@@ -12,7 +12,7 @@ settings = {
 		// Default Authentication Action: override or redirect when a user has not logged in
 		"defaultAuthenticationAction"	: "redirect",
 		// Module override event when an invalid access is detected, instead of each rule declaring one.
-		"invalidAuthorizationEvent"		: "mod1:secure.auth",
+		"invalidAuthorizationEvent"	: "mod1:secure.auth",
 		// Default Authorization Action: override or redirect when a user does not have enough permissions to access something
 		"defaultAuthorizationAction"	: "redirect",
 		// You can define your security rules here
@@ -55,6 +55,7 @@ For example, you can load security rules specific to a module from a JSON file s
 settings = {
 	cbsecurity = {
 		"rules" : "#modulePath#/config/firewallRules.json"
+		// other config here... <---
 	}
 };
 ```

--- a/getting-started/first-chapter/rule-sources/module-rules.md
+++ b/getting-started/first-chapter/rule-sources/module-rules.md
@@ -34,7 +34,7 @@ settings = {
 As you can see each module can have it's own overrides for authentication and authorization events as well as their own rules.
 
 {% hint style="danger" %}
-Please note that these security rules will be **APPENDED** to the global rules
+Please note that these security rules will be **PREPENDED** to the global rules
 {% endhint %}
 
 ### Unloading/Loading

--- a/getting-started/first-chapter/rule-sources/module-rules.md
+++ b/getting-started/first-chapter/rule-sources/module-rules.md
@@ -5,11 +5,11 @@ Every module in ColdBox has the capability to contribute their own rules to `cbs
 {% code title="ModuleConfig.cfc" %}
 ```javascript
 settings = {
-	// CB Security Rules to append to global rules
+	// CB Security Rules to prepend to global rules
 	cbsecurity = {
 		// Module Relocation when an invalid access is detected, instead of each rule declaring one.
 		"invalidAuthenticationEvent" 	: "mod1:secure.index",
-		// Default Auhtentication Action: override or redirect when a user has not logged in
+		// Default Authentication Action: override or redirect when a user has not logged in
 		"defaultAuthenticationAction"	: "redirect",
 		// Module override event when an invalid access is detected, instead of each rule declaring one.
 		"invalidAuthorizationEvent"		: "mod1:secure.auth",
@@ -37,7 +37,29 @@ As you can see each module can have it's own overrides for authentication and au
 Please note that these security rules will be **PREPENDED** to the global rules
 {% endhint %}
 
-### Unloading/Loading
+
+### Rule Sources
+
+As with the global rules defined in `config/Coldbox.cfc`, the module `cbsecurity.rules` setting supports multiple rule sources:
+
+* [DB](untitled)
+* [Inline](inline-rules)
+* [JSON](json-properties)
+* [Model](model-rules)
+* [XML](xml-properties)
+
+For example, you can load security rules specific to a module from a JSON file stored in your module:
+
+{% code title="ModuleConfig.cfc" %}
+```javascript
+settings = {
+	cbsecurity = {
+		"rules" : "#modulePath#/config/firewallRules.json"
+	}
+};
+```
+
+### Loading/Unloading
 
 Also note that if modules are loaded dynamically, it will still inspect them and register them if cbsecurity settings are found.  The same goes for unloading, the entire security rules for that module will cease to exist.
 


### PR DESCRIPTION
Adds documentation for various rule sources. Though I did decide to simply link to the main rule source documentation, as I did not want to start duplicating documentation and cause a maintenance nightmare later.

Also fixed the docs noting that module rules are APPENDED to the global rules. This is no longer true since Will's PR - coldbox-modules/cbsecurity#13 - they are PREPENDED. :+1: 