### PR TITLE
Fix x-auth-token extra backtick

### DIFF
--- a/jwt/refresh-tokens.md
+++ b/jwt/refresh-tokens.md
@@ -120,7 +120,7 @@ CBSecurity has the ability to refresh access tokens automatically for you when c
 
 * access token
   * bearer token or
-  * ```x-auth-token``
+  * `x-auth-token`
 * refresh token
   * `x-refresh-token`
 


### PR DESCRIPTION
Removes an extra backtick showing in the docs.